### PR TITLE
Build against slicer open cv mac

### DIFF
--- a/QuickTCGAEffect/QuickTCGA/Logic/NucleusSeg_Yi/CMakeLists.txt
+++ b/QuickTCGAEffect/QuickTCGA/Logic/NucleusSeg_Yi/CMakeLists.txt
@@ -1,2 +1,3 @@
 set(NucleiSegSrc BinaryMaskAnalysisFilter.cxx Normalization.cpp PixelOperations.cpp ProcessTileUtils.cxx)
 add_library(NucleiSegLib ${NucleiSegSrc})
+target_link_libraries(NucleiSegLib ${QuickTCGA_LIBS})

--- a/QuickTCGAEffect/QuickTCGA/Logic/QuickTCGASegmenter.cxx
+++ b/QuickTCGAEffect/QuickTCGA/Logic/QuickTCGASegmenter.cxx
@@ -1,5 +1,10 @@
 #include "QuickTCGASegmenter.h"
 
+const double QuickTCGASegmenter::m_SAMPLERATE = 0.5;
+const int QuickTCGASegmenter::m_COUNTOURAREA_MIN = 10;
+const int QuickTCGASegmenter::m_COLOR_SLIDER_MAX = 40;
+const int QuickTCGASegmenter::m_STRELE_SIZE = 1;
+
 static void On_TrackColorThreshold(int indColorTh, void* userData) {
 
     QuickTCGASegmenter* pTCGA = static_cast<QuickTCGASegmenter*>(userData);

--- a/QuickTCGAEffect/QuickTCGA/Logic/QuickTCGASegmenter.h
+++ b/QuickTCGAEffect/QuickTCGA/Logic/QuickTCGASegmenter.h
@@ -47,10 +47,10 @@ private:
     cv::Mat m_imFeature;
     std::string m_WindowNameFull;
     std::string m_WindowNameROI;
-    static const double m_SAMPLERATE = 0.5;
-    static const int m_COUNTOURAREA_MIN = 10;
-    static const int m_COLOR_SLIDER_MAX = 40;
-    static const int m_STRELE_SIZE = 1;
+    static const double m_SAMPLERATE;
+    static const int m_COUNTOURAREA_MIN;
+    static const int m_COLOR_SLIDER_MAX;
+    static const int m_STRELE_SIZE;
     std::vector<std::vector<cv::Point> > m_contours;
     std::vector<cv::Vec4i> m_hierarchy;
 };

--- a/ShortCut/ShortCutCore/Logic/ShortCutCoreSegmenter.cxx
+++ b/ShortCut/ShortCutCore/Logic/ShortCutCoreSegmenter.cxx
@@ -1,5 +1,11 @@
 #include "ShortCutCoreSegmenter.h"
 
+// init static variables
+const double ShortCutCoreSegmenter::m_SAMPLERATE = 0.5;
+const int ShortCutCoreSegmenter::m_COUNTOURAREA_MIN = 10;
+const int ShortCutCoreSegmenter::m_COLOR_SLIDER_MAX = 40;
+const int ShortCutCoreSegmenter::m_STRELE_SIZE = 1;
+
 static void On_TrackColorThreshold(int indColorTh, void* userData) {
 
     ShortCutCoreSegmenter* pTCGA = static_cast<ShortCutCoreSegmenter*>(userData);

--- a/ShortCut/ShortCutCore/Logic/ShortCutCoreSegmenter.h
+++ b/ShortCut/ShortCutCore/Logic/ShortCutCoreSegmenter.h
@@ -46,10 +46,10 @@ private:
     cv::Mat m_imFeature;
     std::string m_WindowNameFull;
     std::string m_WindowNameROI;
-    static const double m_SAMPLERATE = 0.5;
-    static const int m_COUNTOURAREA_MIN = 10;
-    static const int m_COLOR_SLIDER_MAX = 40;
-    static const int m_STRELE_SIZE = 1;
+    static const double m_SAMPLERATE;
+    static const int m_COUNTOURAREA_MIN;
+    static const int m_COLOR_SLIDER_MAX;
+    static const int m_STRELE_SIZE;
     std::vector<std::vector<cv::Point> > m_contours;
     std::vector<cv::Vec4i> m_hierarchy;
 };


### PR DESCRIPTION
To get SlicerPathology building on my mac, I had to add the explicity inclusion of target link libraries in NucleiSegLib.
Also cleared up some more compiler warnings.
