### PR TITLE
BUG: update ShortCut name

### DIFF
--- a/ShortCutEffect/ShortCutEffect.py
+++ b/ShortCutEffect/ShortCutEffect.py
@@ -824,7 +824,7 @@ pet = EditorLib.ShortCutTool(sw)
 # ShortCut
 #
 
-class ShortCut:
+class ShortCutEffect:
   """
   This class is the 'hook' for slicer to detect and recognize the extension
   as a loadable scripted module
@@ -849,7 +849,7 @@ class ShortCut:
       slicer.modules.editorExtensions
     except AttributeError:
       slicer.modules.editorExtensions = {}
-    slicer.modules.editorExtensions['ShortCut'] = ShortCutExtension
+    slicer.modules.editorExtensions['ShortCutEffect'] = ShortCutExtension
 
 #
 # ShortCutWidget


### PR DESCRIPTION
During the code reorganisation, the ShortCut class was renamed to
ShortCutEffect, but a class name and a string weren't changed:
https://github.com/SBU-BMI/SlicerPathology/commit/3a732a7b4ef2b061567d2f87fa263e323dc2951c

This fix allows the effect to load into Slicer.
