### PR TITLE
ENH: Provide the custom color file for build, install

### DIFF
--- a/SlicerPathology/CMakeLists.txt
+++ b/SlicerPathology/CMakeLists.txt
@@ -28,3 +28,20 @@ set(MODULE_PYTHON_RESOURCES
   RESOURCES ${MODULE_PYTHON_RESOURCES}
   WITH_GENERIC_TESTS
   )
+
+# copy the color file to the build directory
+set(colorfile "SlicerPathology.csv")
+message(STATUS "Colorfile: build destination directory = ${CMAKE_BINARY_DIR}/${Slicer_SHARE_DIR}/Resources/Colors")
+configure_file(
+  ${CMAKE_CURRENT_SOURCE_DIR}/Resources/Colors/${colorfile}
+  ${CMAKE_BINARY_DIR}/${Slicer_SHARE_DIR}/Resources/Colors/${colorfile}
+  COPYONLY
+  )
+
+# install the color file in the install directory
+message(STATUS "Colorfile: install destination: '${CMAKE_INSTALL_DIR}/Resources/Colors/${colorfile}'")
+install(
+  FILES ${CMAKE_CURRENT_SOURCE_DIR}/Resources/Colors/${colorfile}
+  DESTINATION ${CMAKE_INSTALL_DIR}/Resources/Colors/${colorfile}
+  COMPONENT Runtime
+  )


### PR DESCRIPTION
Added CMake rules to copy the color file into the build directory, as well
as to install it into the install directory when CMAKE_INSTALL_DIR is
set.
