### PR TITLE
BUG: remove the import of SimpleITK

### DIFF
--- a/QuickTCGAEffect/QuickTCGAEffect.py
+++ b/QuickTCGAEffect/QuickTCGAEffect.py
@@ -6,7 +6,6 @@ from EditorLib.EditOptions import HelpButton
 from EditorLib.EditOptions import EditOptions
 from EditorLib import EditUtil
 from EditorLib import LabelEffect
-import SimpleITK as sitk
 
 # Added libs
 from EditorLib import Effect


### PR DESCRIPTION
QuickTCGAEffect isn't using sitk and for development it's often
easier to build Slicer with Simple ITK turned off.
