### PR TITLE
COMP: Add FindSlicerOpenCV for dashboard building.

### DIFF
--- a/CMake/FindSlicerOpenCV.cmake
+++ b/CMake/FindSlicerOpenCV.cmake
@@ -1,0 +1,15 @@
+# For the Slicer dashboard, the build directories should be at the same level.
+set(SOCV_CONFIG_PATHS
+        ${OpenCVExample_BINARY_DIR}/../SlicerOpenCV-build/inner-build
+)
+
+find_file(
+        SLICEROPENCV_CONFIG_FILE
+        SlicerOpenCVConfig.cmake
+        PATHS ${SOCV_CONFIG_PATHS}
+        DOC "The path to the SlicerOpenCVConfig.cmake file"
+         )
+message(STATUS "FindSlicerOpenCV: SLICEROPENCV_CONFIG_FILE = ${SLICEROPENCV_CONFIG_FILE}")
+include(${SLICEROPENCV_CONFIG_FILE})
+message(STATUS "FindSlicerOpenCV: SlicerOpenCV_DIR set to = ${SlicerOpenCV_DIR}")
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,10 @@ set(EXTENSION_DEPENDS "SlicerOpenCV")
 find_package(Slicer REQUIRED)
 include(${Slicer_USE_FILE})
 
+# Add the CMake subdirectory which contains a FindSlicerOpenCV.cmake file
+# that will help find the package automatically
+set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/CMake" ${CMAKE_MODULE_PATH})
+
 find_package(SlicerOpenCV REQUIRED)
 
 #-----------------------------------------------------------------------------


### PR DESCRIPTION
Do not merge unless this discussion confirms this is necessary:
https://github.com/Slicer/Slicer/pull/485

On the factory machine, SlicerPathology's find_package on SlicerOpenCV
is failing, this change gives a hint on where to find the config file.
