### PR TITLE
COMP: Fix windows build error removing unneeded requirement of "sys/time.h"

### DIFF
--- a/QuickTCGA/Logic/NucleusSeg_Yi/Normalization.h
+++ b/QuickTCGA/Logic/NucleusSeg_Yi/Normalization.h
@@ -11,7 +11,6 @@
 // Includes to use opencv2/GPU
 #include "opencv2/opencv.hpp"
 //#include "opencv2/gpu/gpu.hpp"
-#include <sys/time.h>
 
 #include "PixelOperations.h"
 

--- a/QuickTCGA/Logic/NucleusSeg_Yi/TypeUtils.h
+++ b/QuickTCGA/Logic/NucleusSeg_Yi/TypeUtils.h
@@ -9,7 +9,6 @@
 #define UTILS_H_
 
 #include <limits>
-#include <sys/time.h>
 #include <cmath>
 #include <algorithm>
 


### PR DESCRIPTION
Fixes #23
