### PR TITLE
COMP: Fix windows link error ensuring TCGAUtilities symbols are exported.

### DIFF
--- a/QuickTCGA/Logic/TCGAUtilities.h
+++ b/QuickTCGA/Logic/TCGAUtilities.h
@@ -23,6 +23,8 @@
 
 #include <csignal>
 
+#include "vtkSlicerQuickTCGAModuleLogicExport.h"
+
 namespace TCGA
 {
 
@@ -57,11 +59,14 @@ void CopyImageOpenCV2VTK(const cv::Mat &imOpenCV, vtkSmartPointer<vtkImageData> 
 
 
 
-void CopyImageVTK2OpenCV(const vtkSmartPointer<vtkImageData> imVTK, cv::Mat &imOpenCV);
+void VTK_SLICER_QUICKTCGA_MODULE_LOGIC_EXPORT
+CopyImageVTK2OpenCV(const vtkSmartPointer<vtkImageData> imVTK, cv::Mat &imOpenCV);
 
-void CopyImageOpenCV2VTK(const cv::Mat &imOpenCV, vtkSmartPointer<vtkImageData> imVTK);
+void VTK_SLICER_QUICKTCGA_MODULE_LOGIC_EXPORT
+CopyImageOpenCV2VTK(const cv::Mat &imOpenCV, vtkSmartPointer<vtkImageData> imVTK);
 
-void FindBoundingBoxFromMask(const cv::Mat& imMask, cv::Rect& rect);
+void VTK_SLICER_QUICKTCGA_MODULE_LOGIC_EXPORT
+FindBoundingBoxFromMask(const cv::Mat& imMask, cv::Rect& rect);
 
 
 


### PR DESCRIPTION
Fixes #28
