### PR TITLE
COMP: Fix MeanshiftClusteringFilter sign-compare warning. Fixes #24

### DIFF
--- a/QuickTCGA/Logic/NucleusSeg_Yi/MeanshiftClusteringFilter.h
+++ b/QuickTCGA/Logic/NucleusSeg_Yi/MeanshiftClusteringFilter.h
@@ -74,6 +74,8 @@ namespace gth818n
     typename VectorSampleType::Pointer m_seedPoints;
     typename VectorSampleType::Pointer m_centers;
 
+    typedef typename VectorSampleType::InstanceIdentifier VectorSampleSizeType;
+
     VectorType m_inputPointSetRange;
 
 

--- a/QuickTCGA/Logic/NucleusSeg_Yi/MeanshiftClusteringFilter.hxx
+++ b/QuickTCGA/Logic/NucleusSeg_Yi/MeanshiftClusteringFilter.hxx
@@ -129,7 +129,7 @@ namespace gth818n
     VectorType inputPointSetMax;
     inputPointSetMax.Fill(itk::NumericTraits< RealType >::min());
 
-    for (long itp = 0; itp < m_inputPointSet->Size(); ++itp)
+    for (VectorSampleSizeType itp = 0; itp < m_inputPointSet->Size(); ++itp)
       {
         VectorType thisPoint = m_inputPointSet->GetMeasurementVector(itp);
 
@@ -153,7 +153,7 @@ namespace gth818n
 
     for (long it = 0; it < m_numberOfMSIteration; ++it)
       {
-        for (long itp = 0; itp < m_seedPoints->Size(); ++itp)
+        for (VectorSampleSizeType itp = 0; itp < m_seedPoints->Size(); ++itp)
           {
             queryPoint = m_seedPoints->GetMeasurementVector(itp);
             m_tree->Search( queryPoint, m_radius, neighbors ) ;
@@ -161,7 +161,7 @@ namespace gth818n
             VectorType newPosition;
             newPosition.Fill(0);
 
-            for ( unsigned int i = 0 ; i < neighbors.size() ; ++i )
+            for ( VectorSampleSizeType i = 0 ; i < neighbors.size() ; ++i )
               {
                 newPosition += m_tree->GetMeasurementVector( neighbors[i] );
                 //std::cout << m_tree->GetMeasurementVector( neighbors[i] ) << std::endl;
@@ -228,12 +228,12 @@ namespace gth818n
     m_centers = VectorSampleType::New();
     m_centers->PushBack( m_seedPoints->GetMeasurementVector(0) );
 
-    for (unsigned int i = 1 ; i < m_seedPoints->Size() ; ++i )
+    for (VectorSampleSizeType i = 1 ; i < m_seedPoints->Size() ; ++i )
       {
         const VectorType& newCenterCandidate = m_seedPoints->GetMeasurementVector(i);
         bool IAmNotCloseToAnyExistingCenter = true;
 
-        for (unsigned int ii = 0 ; ii < m_centers->Size() ; ++ii )
+        for (VectorSampleSizeType ii = 0 ; ii < m_centers->Size() ; ++ii )
           {
             VectorType distVector = newCenterCandidate - m_centers->GetMeasurementVector(ii);
             if (distVector.GetNorm() < m_radius )
@@ -301,7 +301,7 @@ namespace gth818n
     m_seedPoints = VectorSampleType::New();
     m_seedPoints->Resize(m_inputPointSet->Size() );
 
-    for (unsigned int i = 0 ; i < m_inputPointSet->Size() ; ++i )
+    for (VectorSampleSizeType i = 0 ; i < m_inputPointSet->Size() ; ++i )
       {
         m_seedPoints->SetMeasurementVector( i, m_inputPointSet->GetMeasurementVector(i) );
       }


### PR DESCRIPTION
This commit introduces the `VectorSampleSizeType` typedef facilitating the
writing of code working with the type returned by the
`VectorSampleType::GetSize()`.

For reference, `VectorSampleType` is `itk::Statistics::ListSample< VectorType >`.

See https://itk.org/Doxygen/html/classitk_1_1Statistics_1_1ListSample.html#aa9d5f695ba9713e5dfe45a7ad0956551
