### PR TITLE
COMP: Fix warning reported on Windows. Fixes #33

### DIFF
--- a/QuickTCGA/Logic/NucleusSeg_Yi/Normalization.cpp
+++ b/QuickTCGA/Logic/NucleusSeg_Yi/Normalization.cpp
@@ -249,7 +249,7 @@ namespace nscale
       RGB = [Matrix2 * LMS']';*/
     // OpenCV stores RGB as BGR, so we have the channels inverted as compared to Matlab
     cv::Mat BGRF(LMS.size(), LMS.type());
-    float Matrix2[9] = {4.4687, -3.5887, 0.1196, -1.2197, 2.3831, -0.1626, 0.0585, -0.2611, 1.2057};
+    float Matrix2[9] = {4.4687f, -3.5887f, 0.1196f, -1.2197f, 2.3831f, -0.1626f, 0.0585f, -0.2611f, 1.2057f};
     m11 = Matrix2[0], m12 = Matrix2[1], m13 = Matrix2[2],
       m21 = Matrix2[3], m22 = Matrix2[4], m23 = Matrix2[5],
       m31 = Matrix2[6], m32 = Matrix2[7], m33 = Matrix2[8];
@@ -444,7 +444,7 @@ namespace nscale
     //assert(d == 3);
 
     //% M =[-0.154 0.035 0.549 -45.718; -0.057 -0.817 1.170 -49.887];
-    float mData[8] = {-0.154, 0.035, 0.549, -45.718, -0.057, -0.817, 1.170, -49.887};
+    float mData[8] = {-0.154f, 0.035f, 0.549f, -45.718f, -0.057f, -0.817f, 1.170f, -49.887f};
     cv::Mat M = cv::Mat(2, 4, CV_32FC1, &mData);
 
     //	o_fg = SegFG(OriginalI,M);
@@ -502,8 +502,8 @@ namespace nscale
   {
     for(int i = 0; i < 3; i++)
       {
-        targetMean[i] = i;
-        targetStd[i] = i;
+      targetMean[i] = static_cast<float>(i);
+      targetStd[i] = static_cast<float>(i);
       }
     int r = originalI.rows;
     int c = originalI.cols;
@@ -515,7 +515,7 @@ namespace nscale
       if nargin == 1
       M =[-0.154 0.035 0.549 -45.718; -0.057 -0.817 1.170 -49.887];*/
 
-    float mData[8] = {-0.154, 0.035, 0.549, -45.718, -0.057, -0.817, 1.170, -49.887};
+    float mData[8] = {-0.154f, 0.035f, 0.549f, -45.718f, -0.057f, -0.817f, 1.170f, -49.887f};
     cv::Mat M = cv::Mat(2, 4, CV_32FC1, &mData);
 
     /*


### PR DESCRIPTION
This commit fixes two types of warnings:
- `warning C4305: 'initializing' : truncation from 'double' to 'float'`
- `warning C4244: '=' : conversion from 'int' to 'float', possible loss of data`
