### PR TITLE
Fix wrapping exclusions for VTK 7

### DIFF
--- a/QuickTCGA/Logic/CMakeLists.txt
+++ b/QuickTCGA/Logic/CMakeLists.txt
@@ -32,7 +32,9 @@ set(${KIT}_SRCS
 
 set_source_files_properties(
   ${${KIT}_WRAP_EXCLUDE_SRCS}
-  WRAP_EXCLUDE
+  PROPERTIES
+    WRAP_EXCLUDE 1
+    WRAP_EXCLUDE_PYTHON 1
   )
 
 set(${KIT}_TARGET_LIBRARIES

--- a/ShortCutCore/Logic/CMakeLists.txt
+++ b/ShortCutCore/Logic/CMakeLists.txt
@@ -29,7 +29,9 @@ set(${KIT}_SRCS
 
 set_source_files_properties(
   ${${KIT}_WRAP_EXCLUDE_SRCS}
-  WRAP_EXCLUDE
+  PROPERTIES
+    WRAP_EXCLUDE 1
+    WRAP_EXCLUDE_PYTHON 1
   )
 
 set(${KIT}_TARGET_LIBRARIES


### PR DESCRIPTION
VTK has changed semantics of WRAP_EXCLUDE so that files with that property are
no longer ignored by Python wrapping. To explicitly exclude files from Python
wrapping, it's now necessary to set WRAP_EXCLUDE_PYTHON.

Indeed, SlicerPathology was identified as an extension that might require updates:
https://www.slicer.org/slicerWiki/index.php/Documentation/Labs/VTK7#List_of_extensions_that_may_require_updates

This fixes build errors like the following:

```
SlicerPathology-build/QuickTCGA/Logic/QuickTCGASegmenterPython.cxx:25:28: error: static_cast from 'vtkObjectBase *' to 'QuickTCGASegmenter *' is not allowed
...
SlicerPathology-build/ShortCutCore/Logic/ShortCutPython.cxx:25:18: error: static_cast from 'vtkObjectBase *' to 'ShortCut *' is not allowed
```

One such build that shows these errors is:
http://slicer.cdash.org/viewBuildError.php?buildid=860910
