### PR TITLE
Windows fix

### DIFF
--- a/QuickTCGA/Logic/NucleusSeg_Yi/ConnComponents.cpp
+++ b/QuickTCGA/Logic/NucleusSeg_Yi/ConnComponents.cpp
@@ -7,7 +7,14 @@
 #include "ConnComponents.h"
 #include <string.h>
 
-using namespace std::tr1;
+#if defined(__has_include)
+#if __has_include("unordered_map.h") // Windows
+# include <unordered_map>
+#endif
+#if __has_include("tr1/unordered_map.h") // Linux
+# include <tr1/unordered_map>
+#endif
+#endif
 
 namespace nscale {
 

--- a/QuickTCGA/Logic/NucleusSeg_Yi/ConnComponents.h
+++ b/QuickTCGA/Logic/NucleusSeg_Yi/ConnComponents.h
@@ -9,9 +9,6 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include <tr1/unordered_map>
-
-using namespace std::tr1;
 
 namespace nscale {
 

--- a/QuickTCGA/Logic/NucleusSeg_Yi/Normalization.h
+++ b/QuickTCGA/Logic/NucleusSeg_Yi/Normalization.h
@@ -9,30 +9,33 @@
 #define NORMALIZATION_H_
 
 #include "opencv2/opencv.hpp"
-//#include <sys/time.h>
-
 #include "PixelOperations.h"
 
 
-namespace nscale{
+namespace nscale {
 
-class Normalization {
-private:
-	static void PixelClass(cv::Mat I, cv::Mat o_fg, cv::Mat o_bg, cv::Mat& o_fg_lab, cv::Mat& o_bg_lab);
-	static cv::Mat TransferI(cv::Mat fg_lab, cv::Mat fg_mask, float meanT[3], float stdT[3]);
-	static cv::Mat bgr2Lab(cv::Mat I);
-	static cv::Mat lab2BGR(cv::Mat LAB);
-	static int rndint(float n);
+    class Normalization {
+    private:
+        static void PixelClass(cv::Mat I, cv::Mat o_fg, cv::Mat o_bg, cv::Mat &o_fg_lab, cv::Mat &o_bg_lab);
 
-public:
-	// normalization operations that mimics our matlab code. It uses as an input the BGR image and
-	// mean/std of the lab channels computed from the target image using the function targetParameters bellow.
-	static cv::Mat normalization(const cv::Mat& originalI, float targetMean[3], float targetStd[3]);
-	static void targetParameters(const cv::Mat& originalI, float (&targetMean)[3], float (&targetStd)[3]);
+        static cv::Mat TransferI(cv::Mat fg_lab, cv::Mat fg_mask, float meanT[3], float stdT[3]);
 
-	static cv::Mat segFG(cv::Mat I, cv::Mat M);
+        static cv::Mat bgr2Lab(cv::Mat I);
 
-};
+        static cv::Mat lab2BGR(cv::Mat LAB);
+
+        static int rndint(float n);
+
+    public:
+        // normalization operations that mimics our matlab code. It uses as an input the BGR image and
+        // mean/std of the lab channels computed from the target image using the function targetParameters bellow.
+        static cv::Mat normalization(const cv::Mat &originalI, float targetMean[3], float targetStd[3]);
+
+        static void targetParameters(const cv::Mat &originalI, float (&targetMean)[3], float (&targetStd)[3]);
+
+        static cv::Mat segFG(cv::Mat I, cv::Mat M);
+
+    };
 
 
 }// end nscale

--- a/QuickTCGA/Logic/NucleusSeg_Yi/PixelOperations.cpp
+++ b/QuickTCGA/Logic/NucleusSeg_Yi/PixelOperations.cpp
@@ -7,7 +7,6 @@
 
 #include "PixelOperations.h"
 #include <limits>
-//#include "Logger.h"
 #include "TypeUtils.h"
 
 namespace nscale {

--- a/QuickTCGA/Logic/NucleusSeg_Yi/TypeUtils.h
+++ b/QuickTCGA/Logic/NucleusSeg_Yi/TypeUtils.h
@@ -9,45 +9,44 @@
 #define UTILS_H_
 
 #include <limits>
-//#include <sys/time.h>
 #include <cmath>
 #include <algorithm>
 
 namespace cci {
-namespace common {
-namespace type {
+    namespace common {
+        namespace type {
 
 
-const int DEVICE_CPU = 0;
-const int DEVICE_MCORE = 1;
-const int DEVICE_GPU = 2;
+            const int DEVICE_CPU = 0;
+            const int DEVICE_MCORE = 1;
+            const int DEVICE_GPU = 2;
 
-//convert double to unsigned char
-inline unsigned char double2uchar(double d){
-	double truncate = std::min( std::max(d,(double)0.0), (double)255.0);
-	double pt;
-	double c = modf(truncate, &pt)>=.5?ceil(truncate):floor(truncate);
-	return (unsigned char)c;
+            //convert double to unsigned char
+            inline unsigned char double2uchar(double d) {
+                double truncate = std::min(std::max(d, (double) 0.0), (double) 255.0);
+                double pt;
+                double c = modf(truncate, &pt) >= .5 ? ceil(truncate) : floor(truncate);
+                return (unsigned char) c;
+            }
+
+            template<typename T>
+            inline T min() {
+                if (std::numeric_limits<T>::is_integer) {
+                    return std::numeric_limits<T>::min();
+                } else {
+                    return -std::numeric_limits<T>::max();
+                }
+            }
+
+            template<typename T>
+            inline bool sameSign(T a, T b) {
+                return ((a ^ b) >= 0);
+            }
+
+        }
+
+
+    }
 }
-
-template <typename T>
-inline T min()
-{
-	if (std::numeric_limits<T>::is_integer) {
-		return std::numeric_limits<T>::min();
-	} else {
-		return -std::numeric_limits<T>::max();
-	}
-}
-
-template <typename T>
-inline bool sameSign(T a, T b) {
-	return ((a^b) >= 0);
-}
-
-}
-
-
-}}
 
 #endif /* UTILS_H_ */

--- a/QuickTCGA/Logic/NucleusSeg_Yi/utilityTileAnalysis.cxx
+++ b/QuickTCGA/Logic/NucleusSeg_Yi/utilityTileAnalysis.cxx
@@ -371,6 +371,13 @@ namespace ImagenomicAnalytics {
             return mask;
         }
 
+        /**
+         * Process Tile
+         * declumpingType:
+         * 0 = No declumping
+         * 1 = Mean Shift
+         * 2 = Watershed
+         */
         template<typename TNull>
         itkUCharImageType::Pointer processTile(cv::Mat thisTileCV, \
                                            itkUShortImageType::Pointer &outputLabelImageUShort, \
@@ -562,11 +569,14 @@ namespace ImagenomicAnalytics {
             //outputLabelImageUShort = connected->GetOutput();
             //std::cout << "after ConnectedComponent\n" << std::flush;
 
-            return fhfilter1->GetOutput();
             // return nucleusBinaryMask;
+            return fhfilter1->GetOutput();
         }
 
 
+        /**
+         * NOT USED.
+         */
         template<typename TNull>
         itkUCharImageType::Pointer processTileOptimalThreshold(cv::Mat thisTileCV, \
                                                            itkUShortImageType::Pointer &outputLabelImageUShort, \
@@ -576,7 +586,7 @@ namespace ImagenomicAnalytics {
                                                            double mpp = 0.25, \
                                                            float msKernel = 20.0, \
                                                            int levelsetNumberOfIteration = 100, \
-                                                           bool doDeclump = false) {
+                                                           int declumpingType = 0) {
             std::cout << "normalizeImageColor.....\n" << std::flush;
             cv::Mat newImgCV = normalizeImageColor<char>(thisTileCV);
 
@@ -645,7 +655,7 @@ namespace ImagenomicAnalytics {
                 }
             }
 
-            if (doDeclump) {
+            if (declumpingType == 1) {
                 if (!ScalarImage::isImageAllZero<itkBinaryMaskImageType>(nucleusBinaryMask)) {
                     gth818n::BinaryMaskAnalysisFilter binaryMaskAnalyzer;
                     binaryMaskAnalyzer.setMaskImage(nucleusBinaryMask);
@@ -814,6 +824,13 @@ namespace ImagenomicAnalytics {
         }
 
 
+        /**
+         * Process Tile CV
+         * declumpingType:
+         * 0 = None
+         * 1 = Mean Shift
+         * 2 = Watershed
+         */
         cv::Mat processTileCV(cv::Mat thisTileCV, \
                           float otsuRatio = 1.0, \
                           double curvatureWeight = 0.8, \
@@ -836,10 +853,10 @@ namespace ImagenomicAnalytics {
                                                                        mpp, \
                                                                        msKernel, \
                                                                        levelsetNumberOfIteration,
-                                                                       declumpingType);
+                                                                             declumpingType);
 
             // Transform from 1 to 255 does not work in our Slicer use-case.
-            
+
 /*
             // change pixel values for visualization reasons
             itkUCharImageType::PixelType *nucleusBinaryMaskBufferPointer = nucleusBinaryMask->GetBufferPointer();

--- a/QuickTCGA/Logic/NucleusSeg_Yi/utilityTileAnalysis.h
+++ b/QuickTCGA/Logic/NucleusSeg_Yi/utilityTileAnalysis.h
@@ -11,7 +11,6 @@ namespace ImagenomicAnalytics {
                           float msKernel = 20.0, \
                           int levelsetNumberOfIteration = 100,
                           int seg_type = 0);
-                          //bool doDeclump = false);
     }
 }
 #endif


### PR DESCRIPTION
Windows couldn't find the `#include <tr1/unordered_map.h>`.
They're using Visual Studio 2012 for the Windows build.
It uses: `#include <unordered_map>`.
(See [Microsoft docs](https://msdn.microsoft.com/en-us/library/bb983026(v=vs.110).aspx).)

Therefore, we're now [checking](https://github.com/SBU-BMI/SlicerPathology/blob/develop/QuickTCGA/Logic/NucleusSeg_Yi/ConnComponents.cpp#L10-L17) for the include in `ConnComponents.cpp`, to get the right one.