### PR TITLE
Windows fix 2

### DIFF
--- a/QuickTCGA/Logic/NucleusSeg_Yi/ConnComponents.cpp
+++ b/QuickTCGA/Logic/NucleusSeg_Yi/ConnComponents.cpp
@@ -13,6 +13,7 @@
 #endif
 #if __has_include("tr1/unordered_map.h") // Linux
 # include <tr1/unordered_map>
+using namespace std::tr1;
 #endif
 #endif
 
@@ -97,7 +98,7 @@ namespace nscale {
      */
     int ConnComponents::relabel(int w, int h, int *label, int bgval) {
         int length = w * h;
-        std::tr1::unordered_map<int, int> labelmap;
+        unordered_map<int, int> labelmap;
 
         int j = 1;
         // First find the roots
@@ -143,7 +144,7 @@ namespace nscale {
     int ConnComponents::areaThresholdLabeled(const int *label, const int w, const int h, int *n_label, const int bgval,
                                              const int lower, const int upper) {
         int length = w * h;
-        typedef std::tr1::unordered_map<int, int> AreaMap;
+        typedef unordered_map<int, int> AreaMap;
         AreaMap areas, thresholdedareas;
 
         for (int i = 0; i < length; ++i) {


### PR DESCRIPTION
If `<tr1/unordered_map>` header, then `std::tr1` namespace.
If `<unordered_map>`, then no namespace.